### PR TITLE
修正src/zipmap.h中宏定义

### DIFF
--- a/src/zipmap.h
+++ b/src/zipmap.h
@@ -32,7 +32,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef _ZIMMAP_H
+#ifndef _ZIPMAP_H
 #define _ZIPMAP_H
 
 unsigned char *zipmapNew(void);


### PR DESCRIPTION
src/zipmap.h中的宏定义不正确
